### PR TITLE
NTF-154: Report most recent migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 coverage/
 
 npm-debug.log
+yarn-error.log
 .DS_Store
 
 #IDES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   bluefin:
     build: .
     image: bluefin
+    volumes:
+      - .:/bluefin
     environment:
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_DEFAULT_OUTPUT=$AWS_DEFAULT_OUTPUT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   bluefin:
     build: .
     image: bluefin
-    volumes:
-      - .:/bluefin
+    # volumes:
+    #  - .:/bluefin
     environment:
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_DEFAULT_OUTPUT=$AWS_DEFAULT_OUTPUT

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -58,6 +58,11 @@ export default class Configuration {
     return Sequence.readMigrations(this.fs, absolute, first, last);
   }
 
+  latestMigration(relative) {
+    const absolute = path.resolve(this.directory, relative);
+    return Sequence.getLatestMigration(this.fs, absolute);
+  }
+
   password(name) {
     return this._passwords.then(map => map[name]);
   }

--- a/lib/database.js
+++ b/lib/database.js
@@ -55,6 +55,10 @@ export default class Database extends Entity {
     return this.connect().then(c => this.schema[nick].apply(c, options));
   }
 
+  getLatestOrdinal(nick) {
+    return this.schema[nick].getLatestOrdinal();
+  }
+
   build(options) {
     return this.create()
       .then(() => this.connect())

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -64,6 +64,11 @@ export default class Schema extends Entity {
     return client.value(existsSql, this.name);
   }
 
+  getLatestOrdinal() {
+    const { migrations: absolute } = this.raw;
+    return this.conf.latestMigration(absolute);
+  }
+
   getOrdinalOfLastAppliedMigration(client) {
     return client.value(maxOrdinalSql, this.name);
   }

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -53,6 +53,18 @@ export default class Sequence {
       });
   }
 
+  static async getLatestMigration(fs, dirPath) {
+    const sequence = await this.readMigrations(fs, dirPath);
+
+    for (let i = sequence.programs.length - 1; i >= 0; i--) {
+      if (sequence.programs[i] && sequence.programs[i].ordinal) {
+        return sequence.programs[i].ordinal;
+      }
+    }
+
+    return null;
+  }
+
   constructor() {
     this.programs = [...arguments];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themuse/bluefin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A postgres schema management tool",
   "main": "index.js",
   "bin": "./bin/cli.js",
@@ -16,11 +16,11 @@
     "registry": "https://verdaccio.inf.themuse.com"
   },
   "devDependencies": {
-    "codecov": "~3.1.0",
+    "codecov": "~3.2.0",
     "memfs": "~0.0.9",
-    "mocha": "~5.2.0",
+    "mocha": "~6.0.2",
     "must": "~0.13.4",
-    "nyc": "~13.1.0"
+    "nyc": "~13.3.0"
   },
   "dependencies": {
     "@themuse/muse-lint-tslint": "~0.3.0",
@@ -28,7 +28,7 @@
     "commander": "~2.19.0",
     "husky": "~1.3.1",
     "lint-staged": "~8.1.5",
-    "pg": "~7.8.0",
+    "pg": "~7.9.0",
     "reify": "~0.18.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Discussed today we @mbrochstein how best to orchestrate the deploys since with ECS there's no real way to just shut it all down and turn it all back on with any sort of time certainty. Matt had the idea that we could set in AWS SSM Parameter Store the new migration version that it's about to apply before applying the migrations. Then, all of our services can read the migration version number before doing anything. If it sees that the migration version number in its local copy is too low it can either exit or spin) until it gets shut down by ECS. Meanwhile, when the new code is brought up it'll see it has the latest version of the code to go along with the migrations and keep running.

This change helps us do that. Will point out in incomplete `felix` PR that is coming next how/where it will be used.