### PR TITLE
PLAT-1732 Add deployment logic for Gemfury

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
                 -w /app/workspace \
                 -e NPM_AUTH_TOKEN \
                 -e GEMFURY_TOKEN \
-                circleci/node:9.11 \
+                circleci/node:10 \
                 ./ci/publish $package_name $package_version $dist_tag $CIRCLE_BUILD_NUM $CIRCLE_BRANCH
 
               echo "To install via dist-tag: npm install --save $PACKAGE_NAME@$DIST_TAG"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,17 +93,22 @@ jobs:
       - run:
             name: Publish
             command: |
-              PACKAGE_VERSION=$(cat package.json | jq .version -r)
-              if [ $CIRCLE_BRANCH = 'master' ]; then
-                scripts/docker-run yarn publish --tag latest --new-version "$PACKAGE_VERSION"
-              else
-                PACKAGE_NAME=$(cat package.json | jq .name -r)
-                # Convert the branch name to a valid yarn dist tag value
-                DIST_TAG=$(docker run --rm "themuse/tools:${TOOLS_VERSION:-2.5.8}" generate-deployment-id $CIRCLE_BRANCH)
-                scripts/docker-run yarn --no-git-tag-version --new-version version "$PACKAGE_VERSION-build-$CIRCLE_BUILD_NUM"
-                scripts/docker-run yarn publish --tag $DIST_TAG
-                echo "To install via dist-tag: yarn install --save $PACKAGE_NAME@$DIST_TAG"
-              fi
+              package_name=$(cat package.json | jq .name -r)
+              package_version=$(cat package.json | jq .version -r)
+              dist_tag=$(docker run --rm "$TOOLS_IMAGE" generate-deployment-id $CIRCLE_BRANCH)
+
+              docker run \
+                --rm \
+                --network=container:ovpn \
+                --user root \
+                -v $(pwd):/app/workspace \
+                -w /app/workspace \
+                -e NPM_AUTH_TOKEN \
+                -e GEMFURY_TOKEN \
+                circleci/node:9.11 \
+                ./ci/publish $package_name $package_version $dist_tag $CIRCLE_BUILD_NUM $CIRCLE_BRANCH
+
+              echo "To install via dist-tag: npm install --save $PACKAGE_NAME@$DIST_TAG"
 workflows:
   version: 2
   primary:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
                 -v $(pwd):/app/workspace \
                 -w /app/workspace \
                 -e NPM_AUTH_TOKEN \
-                -e GEMFURY_TOKEN \
+                -e GEMFURY_PUSH_TOKEN \
                 circleci/node:10 \
                 ./ci/publish $package_name $package_version $dist_tag $CIRCLE_BUILD_NUM $CIRCLE_BRANCH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             command: |
               package_name=$(cat package.json | jq .name -r)
               package_version=$(cat package.json | jq .version -r)
-              dist_tag=$(docker run --rm "$TOOLS_IMAGE" generate-deployment-id $CIRCLE_BRANCH)
+              dist_tag=$(docker run --rm "themuse/tools:${TOOLS_VERSION:-2.5.8}" generate-deployment-id $CIRCLE_BRANCH)
 
               docker run \
                 --rm \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
                 --user root \
                 -v $(pwd):/app/workspace \
                 -w /app/workspace \
-                -e NPM_AUTH_TOKEN \
-                -e GEMFURY_PUSH_TOKEN \
+                --env NPM_AUTH_TOKEN \
+                --env GEMFURY_PUSH_TOKEN \
                 circleci/node:10 \
                 ./ci/publish $package_name $package_version $dist_tag $CIRCLE_BUILD_NUM $CIRCLE_BRANCH
 

--- a/ci/publish
+++ b/ci/publish
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+package_name="$1"
+package_version="$2"
+dist_tag="$3"
+circle_build_num="$4"
+circle_branch="$5"
+
+if [[ $circle_branch == "master" ]]; then
+    # Publish to Verdaccio
+    npm publish --tag latest
+
+    # Overwrite .npmrc to point to Gemfury
+    rm .npmrc
+    echo '@themuse:registry=https://npm.fury.io/themuse/' >> .npmrc
+    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_TOKEN}'
+    echo $url >> .npmrc
+
+    # Publish to Gemfury
+    npm publish --tag latest
+else
+    # Publish to Verdaccio
+    npm --no-git-tag-version version "$package_version-build-$circle_build_num"
+    npm publish --tag $dist_tag
+
+    # Overwrite .npmrc to point to Gemfury
+    rm .npmrc
+    echo '@themuse:registry=https://npm.fury.io/themuse/' >> .npmrc
+    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_TOKEN}'
+    echo $url >> .npmrc
+
+    # Publish to Gemfury
+    npm publish --tag $dist_tag
+
+    echo "To install via dist-tag: npm install --save $package_name@$dist_tag"
+fi

--- a/ci/publish
+++ b/ci/publish
@@ -10,7 +10,7 @@ circle_branch="$5"
 
 if [[ $circle_branch == "master" ]]; then
     # Publish to Verdaccio
-    npm publish --tag latest
+    yarn publish --tag latest --new-version $package_version
 
     # Overwrite .npmrc to point to Gemfury
     rm .npmrc
@@ -19,11 +19,11 @@ if [[ $circle_branch == "master" ]]; then
     echo $url >> .npmrc
 
     # Publish to Gemfury
-    npm publish --tag latest
+    yarn publish --tag latest --new-version $package_version
 else
     # Publish to Verdaccio
-    npm --no-git-tag-version version "$package_version-build-$circle_build_num"
-    npm publish --tag $dist_tag
+    yarn --no-git-tag-version version "$package_version-build-$circle_build_num"
+    yarn publish --tag $dist_tag
 
     # Overwrite .npmrc to point to Gemfury
     rm .npmrc
@@ -32,7 +32,7 @@ else
     echo $url >> .npmrc
 
     # Publish to Gemfury
-    npm publish --tag $dist_tag
+    yarn publish --tag $dist_tag
 
-    echo "To install via dist-tag: npm install --save $package_name@$dist_tag"
+    echo "To install via dist-tag: yarn install --save $package_name@$dist_tag"
 fi

--- a/ci/publish
+++ b/ci/publish
@@ -15,7 +15,7 @@ if [[ $circle_branch == "master" ]]; then
     # Overwrite .npmrc to point to Gemfury
     rm .npmrc
     echo '@themuse:registry=https://npm.fury.io/themuse/' >> .npmrc
-    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_TOKEN}'
+    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_PUSH_TOKEN}'
     echo $url >> .npmrc
 
     # Publish to Gemfury
@@ -28,7 +28,7 @@ else
     # Overwrite .npmrc to point to Gemfury
     rm .npmrc
     echo '@themuse:registry=https://npm.fury.io/themuse/' >> .npmrc
-    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_TOKEN}'
+    url='//npm.fury.io/themuse/:_authToken=${GEMFURY_PUSH_TOKEN}'
     echo $url >> .npmrc
 
     # Publish to Gemfury

--- a/ci/publish
+++ b/ci/publish
@@ -22,7 +22,7 @@ if [[ $circle_branch == "master" ]]; then
     yarn publish --tag latest --new-version $package_version
 else
     # Publish to Verdaccio
-    yarn --no-git-tag-version version "$package_version-build-$circle_build_num"
+    yarn --no-git-tag-version --new-version "$package_version-build-$circle_build_num"
     yarn publish --tag $dist_tag
 
     # Overwrite .npmrc to point to Gemfury

--- a/ci/publish
+++ b/ci/publish
@@ -21,8 +21,9 @@ if [[ $circle_branch == "master" ]]; then
     # Publish to Gemfury
     yarn publish --tag latest --new-version $package_version
 else
+    yarn --no-git-tag-version --new-version version "$package_version-build-$circle_build_num"
+    
     # Publish to Verdaccio
-    yarn --no-git-tag-version --new-version "$package_version-build-$circle_build_num"
     yarn publish --tag $dist_tag
 
     # Overwrite .npmrc to point to Gemfury

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   },
   "author": "Daily Muse, Inc.",
   "license": "MIT",
-  "publishConfig": {
-    "registry": "https://verdaccio.inf.themuse.com"
-  },
   "devDependencies": {
     "codecov": "~3.2.0",
     "memfs": "~0.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themuse/bluefin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A postgres schema management tool",
   "main": "index.js",
   "bin": "./bin/cli.js",


### PR DESCRIPTION
Adds deployment logic so that bluefin is published to verdaccio and Gemfury. (This is just a first step in migrating everything over, nothing should change dramatically, the package is just being deployed to two places now).